### PR TITLE
Feature: Mimic UWP's single instance app mode / 功能：模仿 UWP 的单实例应用模式

### DIFF
--- a/EnergyStarX/EnergyStarX.csproj
+++ b/EnergyStarX/EnergyStarX.csproj
@@ -38,7 +38,6 @@
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.5.3" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.5.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.5" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="NLog" Version="5.0.5" />

--- a/EnergyStarX/Program.cs
+++ b/EnergyStarX/Program.cs
@@ -1,6 +1,4 @@
-﻿using EnergyStarX.Helpers;
-using Microsoft.Toolkit.Uwp.Notifications;
-using Microsoft.UI.Dispatching;
+﻿using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
 
@@ -11,12 +9,12 @@ namespace EnergyStarX;
 public static class Program
 {
     [STAThread]
-    private static void Main(string[] args)
+    private static async Task Main(string[] args)
     {
-        AppInstance mainInstance = AppInstance.FindOrRegisterForKey(App.Guid);
-        if (!mainInstance.IsCurrent)
+        AppInstance mainAppInstance = AppInstance.FindOrRegisterForKey(App.Guid);
+        if (!mainAppInstance.IsCurrent)
         {
-            new ToastContentBuilder().AddText("AlreadyRunningMessage".ToLocalized()).Show();
+            await mainAppInstance.RedirectActivationToAsync(AppInstance.GetCurrent().GetActivatedEventArgs());
             return;
         }
 

--- a/EnergyStarX/Services/ActivationService.cs
+++ b/EnergyStarX/Services/ActivationService.cs
@@ -1,8 +1,9 @@
-﻿using EnergyStarX.Activation;
+﻿using CommunityToolkit.WinUI;
+using EnergyStarX.Activation;
 using EnergyStarX.Contracts.Services;
 using EnergyStarX.ViewModels;
 using EnergyStarX.Views;
-
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.AppLifecycle;
@@ -11,6 +12,9 @@ namespace EnergyStarX.Services;
 
 public class ActivationService : IActivationService
 {
+    private readonly AppInstance currentAppInstance = AppInstance.GetCurrent();
+    private readonly DispatcherQueue dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+
     private readonly ActivationHandler<LaunchActivatedEventArgs> defaultHandler;
     private readonly IEnumerable<IActivationHandler> activationHandlers;
     private UIElement? shell = null;
@@ -78,22 +82,37 @@ public class ActivationService : IActivationService
         }
     }
 
+    /// <summary>
+    /// Execute tasks before activation.
+    /// </summary>
     private async Task Initialize()
     {
         await startupService.Initialize();
     }
 
+    /// <summary>
+    /// Execute tasks after activation.
+    /// </summary>
     private async Task Startup()
     {
         windowService.Initialize();
         energyService.Initialize();
         await systemTrayIconService.Initialize();
+
+        currentAppInstance.Activated += OnActivated;
+    }
+
+    private async void OnActivated(object? sender, AppActivationArguments e)
+    {
+        // Mimic UWP's single instance app mode
+        // When launching a second app instance, redirect activation to the main app instance (in Program.cs), and show main instance's app window
+        await dispatcherQueue.EnqueueAsync(() => windowService.ShowAppWindow());
     }
 
     private bool ShouldShowAppWindow()
     {
         // If app is run at startup, don't show app window during activation
-        if (AppInstance.GetCurrent().GetActivatedEventArgs().Kind == ExtendedActivationKind.StartupTask)
+        if (currentAppInstance.GetActivatedEventArgs().Kind == ExtendedActivationKind.StartupTask)
         {
             return false;
         }

--- a/EnergyStarX/Services/ActivationService.cs
+++ b/EnergyStarX/Services/ActivationService.cs
@@ -99,13 +99,13 @@ public class ActivationService : IActivationService
         energyService.Initialize();
         await systemTrayIconService.Initialize();
 
-        currentAppInstance.Activated += OnActivated;
+        currentAppInstance.Activated += CurrentAppInstance_Activated;
     }
 
-    private async void OnActivated(object? sender, AppActivationArguments e)
+    private async void CurrentAppInstance_Activated(object? sender, AppActivationArguments e)
     {
         // Mimic UWP's single instance app mode
-        // When launching a second app instance, redirect activation to the main app instance (in Program.cs), and show main instance's app window
+        // When launching a second app instance, redirect activation to the main app instance (see Program.cs), and show main instance's app window
         await dispatcherQueue.EnqueueAsync(() => windowService.ShowAppWindow());
     }
 


### PR DESCRIPTION
### Current behavior:

When launching a second app instance, show a toast notification that tells user the app is already running, and exit.

### New behavior:

When launching a second app instance, redirect activation to the main app instance, and show main instance's app window, just like UWP's default behavior.

### Problems:

There's something wrong with GitHub Action's CI builds. When I launch a second instance, `RedirectActivationToAsync` in `Program.cs` will crash the app, so main instance's window will not show. The exception message is:

```
The process was terminated due to an unhandled exception.
Exception Info: System.Runtime.InteropServices.COMException (0x80040155): Interface not registered (0x80040155)
```

If I compile the app on my PC it works fine.

----------

### 当前行为：

启动第二个应用实例时，弹出一条通知告诉用户应用已经在运行，然后退出。

### 新的行为：

启动第二个应用实例时，把激活重定向到主实例，并显示主实例的窗口，就像 UWP 的默认行为一样。

### 问题：

GitHub Action 的 CI 构建的包有点问题。启动第二个实例时，`Program.cs` 中的 `RedirectActivationToAsync` 会使应用崩溃，所以主实例的窗口不会显示。异常信息为：

```
The process was terminated due to an unhandled exception.
Exception Info: System.Runtime.InteropServices.COMException (0x80040155): Interface not registered (0x80040155)
```

在我的电脑上编译就没有这个问题。