### PR TITLE
Fix: System tray icon disappears after Explorer restarts / 修复：系统托盘图标在 Explorer 重启后消失

### DIFF
--- a/EnergyStarX/Services/SystemTrayIconService.cs
+++ b/EnergyStarX/Services/SystemTrayIconService.cs
@@ -50,6 +50,23 @@ public class SystemTrayIconService
             }
         };
 
+        // When taskbar restarts (for example when explorer crashes and restarts), recreate system tray icon.
+        // Or the system tray icon will disappear.
+        trayIcon.MessageWindow.TaskbarCreated += (s, e) =>
+        {
+            logger.Info("Taskbar restarted. Recreating system tray icon...");
+
+            try
+            {
+                trayIcon.TryRemove();
+                trayIcon.Create();
+            }
+            catch (Exception ex)
+            {
+                logger.Warn(ex, "Failed to recreate system tray icon");
+            }
+        };
+
         trayIcon.Create();
 
         windowService.AppExiting += WindowService_AppExiting;


### PR DESCRIPTION
## Current Behavior

When Explorer restarts (for example, when it crashes), app's system tray icon will disappear.

## New Behavior

The tray icon will not disappear after Explorer restarts.

----------

## 当前行为

当 Explorer 重启时（例如，当它崩溃时），应用的系统托盘图标会消失。

## 新的行为

Explorer 重启后，托盘图标不会消失。