### PR TITLE
Enable .NET IL trimming to reduce app size

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -98,6 +98,7 @@ jobs:
           /p:GenerateAppxPackageOnBuild=true `
           /p:WindowsAppSDKSelfContained=true `
           /p:SelfContained=true `
+          /p:PublishReadyToRun=false `
           /p:RuntimeIdentifier=win10-${{ matrix.platform }}
       env:
         Appx_Bundle: Never

--- a/.gitignore
+++ b/.gitignore
@@ -184,7 +184,7 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
+# *.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/EnergyStarX/EnergyStarX.csproj
+++ b/EnergyStarX/EnergyStarX.csproj
@@ -22,8 +22,14 @@
     <SupportedOSPlatformVersion>10.0.22000.0</SupportedOSPlatformVersion>
     <AppxBundlePlatforms>x64|arm64</AppxBundlePlatforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <!-- Enable .NET IL trimming to reduce app size -->
+  <!-- In order to get hardware info with WmiLight, we need COM support  -->
+  <PropertyGroup>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>partial</TrimMode>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,7 +41,6 @@
     <PackageReference Include="CommunityToolkit.WinUI" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
     <PackageReference Include="H.NotifyIcon" Version="2.0.94" />
-    <PackageReference Include="Hardware.Info" Version="10.1.1" />
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.1" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
@@ -48,6 +53,7 @@
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Flurl" Version="3.0.7" />
+    <PackageReference Include="WmiLight" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EnergyStarX/EnergyStarX.csproj
+++ b/EnergyStarX/EnergyStarX.csproj
@@ -24,9 +24,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <!-- Enable .NET IL trimming to reduce app size -->
-  <!-- In order to get hardware info with WmiLight, we need COM support  -->
-  <PropertyGroup>
+  <!-- Enable .NET IL trimming in release mode to reduce app size -->
+  <!-- We need COM support to get hardware info with WmiLight -->
+  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>partial</TrimMode>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>

--- a/EnergyStarX/EnergyStarX.csproj
+++ b/EnergyStarX/EnergyStarX.csproj
@@ -9,9 +9,9 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
-	<ImplicitUsings>enable</ImplicitUsings>
-	<Nullable>enable</Nullable>
-	<UseWinUI>true</UseWinUI>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <GenerateTemporaryStoreCertificate>True</GenerateTemporaryStoreCertificate>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
@@ -22,6 +22,8 @@
     <SupportedOSPlatformVersion>10.0.22000.0</SupportedOSPlatformVersion>
     <AppxBundlePlatforms>x64|arm64</AppxBundlePlatforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,7 +42,6 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230217.4" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="NLog" Version="5.1.2" />
-    <PackageReference Include="TaskScheduler" Version="2.10.1" />
     <PackageReference Include="WinUICommunity.SettingsUI" Version="3.1.1" />
     <PackageReference Include="WinUIEx" Version="2.1.0" />
     <PackageReference Include="DependencyPropertyGenerator" Version="1.2.2" PrivateAssets="all" ExcludeAssets="runtime">
@@ -110,7 +111,7 @@
       <DependentUpon>SettingsHelper.tt</DependentUpon>
     </Compile>
   </ItemGroup>
-  
+
   <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
   </PropertyGroup>

--- a/EnergyStarX/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/EnergyStarX/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>arm64</Platform>
+    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+  </PropertyGroup>
+</Project>

--- a/EnergyStarX/Properties/PublishProfiles/win10-x64.pubxml
+++ b/EnergyStarX/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Solve #14 .

Currently the `TrimMode` is set to `partial`, since `full` is too aggressive.
Need some time to test and make sure it doesn't break app's functionality.

## Size comparision

App size is reduced by 50%.

||Before (MB)|After (MB)|
|---|---|---|
|Unpackaged|146|65|
|MSIX|57|29|

## Note

`TaskScheduler` is removed from dependencies because it uses COM to interact with Windows Task Scheduler and is incompatible with IL trimming. 
Instead I use `schtasks` get the status of the admin startup schedule task.