### PR TITLE
Replace WinUICommunity.SettingsUI with CommunityToolkit.Labs.WinUI.SettingsControls

### DIFF
--- a/src/EnergyStarX/App.xaml
+++ b/src/EnergyStarX/App.xaml
@@ -19,7 +19,6 @@
                 <ResourceDictionary Source="/Styles/Thickness.xaml" />
                 <ResourceDictionary Source="/Styles/TextBlock.xaml" />
                 <ResourceDictionary Source="/Styles/Layout.xaml" />
-                <ResourceDictionary Source="ms-appx:///SettingsUI/Themes/Generic.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/src/EnergyStarX/EnergyStarX.csproj
+++ b/src/EnergyStarX/EnergyStarX.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.18" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
     <PackageReference Include="CommunityToolkit.WinUI" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
@@ -47,7 +48,6 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="NLog" Version="5.1.2" />
-    <PackageReference Include="WinUICommunity.SettingsUI" Version="3.2.2" />
     <PackageReference Include="WinUIEx" Version="2.1.0" />
     <PackageReference Include="DependencyPropertyGenerator" Version="1.2.4" PrivateAssets="all" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EnergyStarX/Views/LogPage.xaml
+++ b/src/EnergyStarX/Views/LogPage.xaml
@@ -44,7 +44,7 @@
 
             <AppBarButton x:Uid="Log_OpenLogFolderButton" Command="{x:Bind ViewModel.OpenLogFolderCommand}">
                 <AppBarButton.Icon>
-                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xED25;" />
+                    <FontIcon Glyph="&#xED25;" />
                 </AppBarButton.Icon>
             </AppBarButton>
         </CommandBar>

--- a/src/EnergyStarX/Views/SettingsPage.xaml
+++ b/src/EnergyStarX/Views/SettingsPage.xaml
@@ -6,8 +6,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:lab="using:CommunityToolkit.Labs.WinUI"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:settingsUI="using:WinUICommunity.SettingsUI.Controls"
     xmlns:xaml="using:Microsoft.UI.Xaml"
     NavigationCacheMode="Enabled"
     mc:Ignorable="d">
@@ -35,10 +35,9 @@
             <Setter Property="Margin" Value="0,8,0,0" />
         </Style>
 
-        <Thickness x:Key="SettingsExpanderHeaderMargin">0,0,24,0</Thickness>
-        <Thickness x:Key="SettingsExpanderContentMargin">56,10,24,10</Thickness>
+        <Thickness x:Key="SettingsExpanderContentMargin">0,0,28,0</Thickness>
+        <Thickness x:Key="SettingsExpanderItemMargin">56,10,24,10</Thickness>
 
-        <Style BasedOn="{StaticResource ToggleSwitchSettingStyle}" TargetType="ToggleSwitch" />
         <Style TargetType="HyperlinkButton" />
     </Page.Resources>
 
@@ -101,49 +100,53 @@
                     <TextBlock x:Uid="Settings_Title" Style="{StaticResource TitleStyle}" />
 
                     <StackPanel Margin="{StaticResource SubContentBlockMargin}">
-                        <settingsUI:SettingExpander>
-                            <settingsUI:SettingExpander.Header>
-                                <settingsUI:Setting x:Uid="Settings_RunAtStartupSetting" Icon="&#xE7F8;">
-                                    <settingsUI:Setting.ActionContent>
-                                        <ToggleSwitch IsEnabled="{x:Bind ViewModel.IsRunAtStartupToggleable, Mode=OneWay}" IsOn="{x:Bind ViewModel.RunAtStartup, Mode=TwoWay}" />
-                                    </settingsUI:Setting.ActionContent>
-                                </settingsUI:Setting>
-                            </settingsUI:SettingExpander.Header>
+                        <lab:SettingsExpander x:Uid="Settings_RunAtStartupSetting">
+                            <lab:SettingsExpander.HeaderIcon>
+                                <FontIcon Glyph="&#xE7F8;" />
+                            </lab:SettingsExpander.HeaderIcon>
 
-                            <settingsUI:SettingExpander.Content>
+                            <ToggleSwitch IsEnabled="{x:Bind ViewModel.IsRunAtStartupToggleable, Mode=OneWay}" IsOn="{x:Bind ViewModel.RunAtStartup, Mode=TwoWay}" />
+
+                            <lab:SettingsExpander.Items>
                                 <CheckBox
                                     x:Uid="Settings_RunAtStartupAsAdminCheckBox"
-                                    Margin="{StaticResource SettingsExpanderContentMargin}"
+                                    Margin="{StaticResource SettingsExpanderItemMargin}"
                                     IsChecked="{x:Bind ViewModel.RunAtStartupAsAdmin, Mode=TwoWay}"
                                     IsEnabled="{x:Bind ViewModel.IsRunAtStartupAsAdminToggleable, Mode=OneWay}" />
-                            </settingsUI:SettingExpander.Content>
-                        </settingsUI:SettingExpander>
+                            </lab:SettingsExpander.Items>
+                        </lab:SettingsExpander>
 
-                        <settingsUI:Setting x:Uid="Settings_ThrottleWhenPluggedIn" Icon="&#xEBB1;">
-                            <settingsUI:Setting.ActionContent>
-                                <ToggleSwitch Margin="{StaticResource SettingsExpanderHeaderMargin}" IsOn="{x:Bind ViewModel.ThrottleWhenPluggedIn, Mode=TwoWay}" />
-                            </settingsUI:Setting.ActionContent>
-                        </settingsUI:Setting>
+                        <lab:SettingsCard x:Uid="Settings_ThrottleWhenPluggedIn">
+                            <lab:SettingsCard.HeaderIcon>
+                                <FontIcon Glyph="&#xEBB1;" />
+                            </lab:SettingsCard.HeaderIcon>
 
-                        <settingsUI:Setting x:Uid="Settings_ProcessWhitelist" Icon="&#xF16C;">
-                            <settingsUI:Setting.ActionContent>
-                                <StackPanel Margin="{StaticResource SettingsExpanderHeaderMargin}" Orientation="Horizontal">
-                                    <Button x:Uid="Settings_ProcessWhitelist_EditButton" Command="{x:Bind ViewModel.ShowProcessWhitelistEditorDialogCommand}" />
-                                    <Grid Width="10" />
-                                    <Button x:Uid="Settings_ProcessWhitelist_RestoreToDefaultButton" Command="{x:Bind ViewModel.RestoreToDefaultProcessWhitelistCommand}" />
-                                </StackPanel>
-                            </settingsUI:Setting.ActionContent>
-                        </settingsUI:Setting>
+                            <ToggleSwitch Margin="{StaticResource SettingsExpanderContentMargin}" IsOn="{x:Bind ViewModel.ThrottleWhenPluggedIn, Mode=TwoWay}" />
+                        </lab:SettingsCard>
 
-                        <settingsUI:Setting x:Uid="Settings_ProcessBlacklist" Icon="&#xF16D;">
-                            <settingsUI:Setting.ActionContent>
-                                <StackPanel Margin="{StaticResource SettingsExpanderHeaderMargin}" Orientation="Horizontal">
-                                    <Button x:Uid="Settings_ProcessBlacklist_EditButton" Command="{x:Bind ViewModel.ShowProcessBlacklistEditorDialogCommand}" />
-                                    <Grid Width="10" />
-                                    <Button x:Uid="Settings_ProcessBlacklist_RestoreToDefaultButton" Command="{x:Bind ViewModel.RestoreToDefaultProcessBlacklistCommand}" />
-                                </StackPanel>
-                            </settingsUI:Setting.ActionContent>
-                        </settingsUI:Setting>
+                        <lab:SettingsCard x:Uid="Settings_ProcessWhitelist">
+                            <lab:SettingsCard.HeaderIcon>
+                                <FontIcon Glyph="&#xF16C;" />
+                            </lab:SettingsCard.HeaderIcon>
+
+                            <StackPanel Margin="{StaticResource SettingsExpanderContentMargin}" Orientation="Horizontal">
+                                <Button x:Uid="Settings_ProcessWhitelist_EditButton" Command="{x:Bind ViewModel.ShowProcessWhitelistEditorDialogCommand}" />
+                                <Grid Width="10" />
+                                <Button x:Uid="Settings_ProcessWhitelist_RestoreToDefaultButton" Command="{x:Bind ViewModel.RestoreToDefaultProcessWhitelistCommand}" />
+                            </StackPanel>
+                        </lab:SettingsCard>
+
+                        <lab:SettingsCard x:Uid="Settings_ProcessBlacklist">
+                            <lab:SettingsCard.HeaderIcon>
+                                <FontIcon Glyph="&#xF16D;" />
+                            </lab:SettingsCard.HeaderIcon>
+
+                            <StackPanel Margin="{StaticResource SettingsExpanderContentMargin}" Orientation="Horizontal">
+                                <Button x:Uid="Settings_ProcessBlacklist_EditButton" Command="{x:Bind ViewModel.ShowProcessBlacklistEditorDialogCommand}" />
+                                <Grid Width="10" />
+                                <Button x:Uid="Settings_ProcessBlacklist_RestoreToDefaultButton" Command="{x:Bind ViewModel.RestoreToDefaultProcessBlacklistCommand}" />
+                            </StackPanel>
+                        </lab:SettingsCard>
                     </StackPanel>
 
                     <TextBlock x:Uid="Settings_About" Style="{ThemeResource SubTitleStyle}" />

--- a/src/EnergyStarX/Views/SettingsPage.xaml
+++ b/src/EnergyStarX/Views/SettingsPage.xaml
@@ -96,9 +96,17 @@
                 MaxWidth="800"
                 HorizontalAlignment="Center">
                 <StackPanel Margin="{StaticResource NavigationViewPageContentMargin}" HorizontalAlignment="Stretch">
+                    <StackPanel.ChildrenTransitions>
+                        <RepositionThemeTransition IsStaggeringEnabled="False" />
+                    </StackPanel.ChildrenTransitions>
+
                     <TextBlock x:Uid="Settings_Title" Style="{StaticResource TitleStyle}" />
 
                     <StackPanel Margin="{StaticResource SubContentBlockMargin}">
+                        <StackPanel.ChildrenTransitions>
+                            <RepositionThemeTransition IsStaggeringEnabled="False" />
+                        </StackPanel.ChildrenTransitions>
+
                         <lab:SettingsExpander x:Uid="Settings_RunAtStartupSetting">
                             <lab:SettingsExpander.HeaderIcon>
                                 <FontIcon Glyph="&#xE7F8;" />

--- a/src/EnergyStarX/Views/SettingsPage.xaml
+++ b/src/EnergyStarX/Views/SettingsPage.xaml
@@ -36,7 +36,6 @@
         </Style>
 
         <Thickness x:Key="SettingsExpanderContentMargin">0,0,28,0</Thickness>
-        <Thickness x:Key="SettingsExpanderItemMargin">56,10,24,10</Thickness>
 
         <Style TargetType="HyperlinkButton" />
     </Page.Resources>
@@ -108,11 +107,12 @@
                             <ToggleSwitch IsEnabled="{x:Bind ViewModel.IsRunAtStartupToggleable, Mode=OneWay}" IsOn="{x:Bind ViewModel.RunAtStartup, Mode=TwoWay}" />
 
                             <lab:SettingsExpander.Items>
-                                <CheckBox
-                                    x:Uid="Settings_RunAtStartupAsAdminCheckBox"
-                                    Margin="{StaticResource SettingsExpanderItemMargin}"
-                                    IsChecked="{x:Bind ViewModel.RunAtStartupAsAdmin, Mode=TwoWay}"
-                                    IsEnabled="{x:Bind ViewModel.IsRunAtStartupAsAdminToggleable, Mode=OneWay}" />
+                                <lab:SettingsCard ContentAlignment="Left">
+                                    <CheckBox
+                                        x:Uid="Settings_RunAtStartupAsAdminCheckBox"
+                                        IsChecked="{x:Bind ViewModel.RunAtStartupAsAdmin, Mode=TwoWay}"
+                                        IsEnabled="{x:Bind ViewModel.IsRunAtStartupAsAdminToggleable, Mode=OneWay}" />
+                                </lab:SettingsCard>
                             </lab:SettingsExpander.Items>
                         </lab:SettingsExpander>
 

--- a/src/EnergyStarX/Views/ShellPage.xaml
+++ b/src/EnergyStarX/Views/ShellPage.xaml
@@ -56,19 +56,19 @@
                 -->
                 <NavigationViewItem x:Uid="Shell_Home" helpers:NavigationHelper.NavigateTo="EnergyStarX.ViewModels.HomeViewModel">
                     <NavigationViewItem.Icon>
-                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE10F;" />
+                        <FontIcon Glyph="&#xE10F;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
 
                 <NavigationViewItem x:Uid="Shell_Log" helpers:NavigationHelper.NavigateTo="EnergyStarX.ViewModels.LogViewModel">
                     <NavigationViewItem.Icon>
-                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE7C3;" />
+                        <FontIcon Glyph="&#xE7C3;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
 
                 <NavigationViewItem x:Uid="Shell_Help" helpers:NavigationHelper.NavigateTo="EnergyStarX.ViewModels.HelpViewModel">
                     <NavigationViewItem.Icon>
-                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE11B;" />
+                        <FontIcon Glyph="&#xE11B;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
             </NavigationView.MenuItems>
@@ -77,10 +77,7 @@
                 <StackPanel Orientation="Horizontal">
                     <Button>
                         <StackPanel Orientation="Horizontal">
-                            <FontIcon
-                                FontFamily="Segoe Fluent Icons"
-                                FontSize="16"
-                                Glyph="&#xE006;" />
+                            <FontIcon FontSize="16" Glyph="&#xE006;" />
                             <TextBlock x:Uid="Shell_DonateTextBlock" Margin="12,0,0,0" />
                         </StackPanel>
 

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -4,6 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="nuget" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" />
+    <add key="nuget-communitytoolkit-labs" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
In SettingsPage, replace: 
`Setting` and `SettingExpander` from [WinUICommunity/SettingsUI](https://github.com/WinUICommunity/SettingsUI) 
with:
`SettingsCard` and `SettingsExpander` from [Community Toolkit Lab's SettingsControls](https://github.com/CommunityToolkit/Labs-Windows/issues/216).

Currently, Community Toolkit Lab's SettingsControls is still in preview stage. It will be officially released with Community Toolkit 8.0 in the first half of 2023.