### PR TITLE
Supports "?" and "*" wildcards in process white / black list

### DIFF
--- a/src/EnergyStarX/Services/EnergyService.cs
+++ b/src/EnergyStarX/Services/EnergyService.cs
@@ -8,6 +8,7 @@ using EnergyStarX.Core.Interop;
 using Microsoft.Windows.System.Power;
 using NLog;
 using System.Diagnostics;
+using System.IO.Enumeration;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -97,9 +98,19 @@ public class EnergyService
     public IReadOnlySet<string> ProcessWhitelist { get; private set; } = new HashSet<string>();
 
     /// <summary>
+    /// A subset of <see cref="ProcessWhitelist" />, where the process name contains "?" or "*".
+    /// </summary>
+    private IReadOnlySet<string> WildcardProcessWhitelist { get; set; } = new HashSet<string>();
+
+    /// <summary>
     /// Processes in blacklist will be throttled even when device is plugged in
     /// </summary>
     public IReadOnlySet<string> ProcessBlacklist { get; private set; } = new HashSet<string>();
+
+    /// <summary>
+    /// A subset of <see cref="ProcessBlacklist" />, where the process name contains "?" or "*".
+    /// </summary>
+    private IReadOnlySet<string> WildcardProcessBlacklist { get; set; } = new HashSet<string>();
 
     public bool IsOnBattery => PowerManager.PowerSourceKind == PowerSourceKind.DC;
 
@@ -181,11 +192,12 @@ public class EnergyService
                 StopThrottling(previousThrottleStatus);
             }
 
-            HashSet<string> processWhitelist = ParseProcessList(processWhitelistString);
+            (HashSet<string> processWhitelist, HashSet<string> wildcardProcessWhitelist) = ParseProcessList(processWhitelistString);
 #if DEBUG
             processWhitelist.Add("devenv.exe");    // Visual Studio
 #endif
             ProcessWhitelist = processWhitelist;
+            WildcardProcessWhitelist = wildcardProcessWhitelist;
 
             logger.Info("Apply ProcessWhitelist:\n{0}", string.Join(Environment.NewLine, processWhitelist));
 
@@ -217,8 +229,9 @@ public class EnergyService
                 StopThrottling(previousThrottleStatus);
             }
 
-            HashSet<string> processBlacklist = ParseProcessList(processBlacklistString);
+            (HashSet<string> processBlacklist, HashSet<string> wildcardProcessBlacklist) = ParseProcessList(processBlacklistString);
             ProcessBlacklist = processBlacklist;
+            WildcardProcessBlacklist = wildcardProcessBlacklist;
 
             logger.Info("Apply ProcessBlacklist:\n{0}", string.Join(Environment.NewLine, processBlacklist));
 
@@ -235,9 +248,14 @@ public class EnergyService
     /// Each line of <paramref name="processListString"/> contains one process name;
     /// Double slash and content after it in each line will be ignored.
     /// </summary>
-    private HashSet<string> ParseProcessList(string processListString)
+    /// <returns>
+    /// In the returned tuple, "wildcardProcessList" is a subset of "fullProcessList", where the process name contains "?" or "*".
+    /// </returns>
+    private (HashSet<string> fullProcessList, HashSet<string> wildcardProcessList) ParseProcessList(string processListString)
     {
-        HashSet<string> result = new();
+        HashSet<string> fullProcessList = new();
+        HashSet<string> wildcardProcessList = new();
+
         Regex doubleSlashRegex = new("//");
 
         using StringReader stringReader = new(processListString);
@@ -247,11 +265,16 @@ public class EnergyService
             string processName = (doubleSlashMatch.Success ? line[..doubleSlashMatch.Index] : line).Trim().ToLowerInvariant();
             if (!string.IsNullOrEmpty(processName))
             {
-                result.Add(processName);
+                fullProcessList.Add(processName);
+
+                if (processName.Contains("?") || processName.Contains("*"))
+                {
+                    wildcardProcessList.Add(processName);
+                }
             }
         }
 
-        return result;
+        return (fullProcessList, wildcardProcessList);
     }
 
     /// <summary>
@@ -489,15 +512,47 @@ public class EnergyService
         }
     }
 
-    private bool ShouldBypassProcess(string processName, ThrottleStatus throttleStatus)
+    private bool ShouldBypassProcess(string processName, ThrottleStatus throttleStatus) => !ShouldThrottleProcess(processName, throttleStatus);
+
+    private bool ShouldThrottleProcess(string processName, ThrottleStatus throttleStatus)
     {
         return throttleStatus switch
         {
-            ThrottleStatus.Stopped => true,
-            ThrottleStatus.OnlyBlacklist => !ProcessBlacklist.Contains(processName.ToLowerInvariant()),
-            ThrottleStatus.BlacklistAndAllButWhitelist => !ProcessBlacklist.Contains(processName.ToLowerInvariant()) && ProcessWhitelist.Contains(processName.ToLowerInvariant()),
+            ThrottleStatus.Stopped => false,
+            ThrottleStatus.OnlyBlacklist => IsProcessInBlacklist(processName),
+            ThrottleStatus.BlacklistAndAllButWhitelist => IsProcessInBlacklist(processName) || !IsProcessInWhitelist(processName),
             _ => throw new ArgumentException("Unknown ThrottleStatus")
         };
+    }
+
+    private bool IsProcessInWhitelist(string processName)
+    {
+        if (ProcessWhitelist.Contains(processName.ToLowerInvariant()))
+        {
+            return true;
+        }
+
+        if (WildcardProcessWhitelist.Any(wildcardExpression => FileSystemName.MatchesSimpleExpression(wildcardExpression, processName, true)))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsProcessInBlacklist(string processName)
+    {
+        if (ProcessBlacklist.Contains(processName.ToLowerInvariant()))
+        {
+            return true;
+        }
+
+        if (WildcardProcessBlacklist.Any(wildcardExpression => FileSystemName.MatchesSimpleExpression(wildcardExpression, processName, true)))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private void ToggleEfficiencyMode(IntPtr hProcess, bool enable)

--- a/src/EnergyStarX/Services/EnergyService.cs
+++ b/src/EnergyStarX/Services/EnergyService.cs
@@ -526,28 +526,23 @@ public class EnergyService
     }
 
     private bool IsProcessInWhitelist(string processName)
-    {
-        if (ProcessWhitelist.Contains(processName.ToLowerInvariant()))
-        {
-            return true;
-        }
-
-        if (WildcardProcessWhitelist.Any(wildcardExpression => FileSystemName.MatchesSimpleExpression(wildcardExpression, processName, true)))
-        {
-            return true;
-        }
-
-        return false;
+    {   
+        return IsProcesInList(processName, ProcessWhitelist, WildcardProcessWhitelist);
     }
 
     private bool IsProcessInBlacklist(string processName)
     {
-        if (ProcessBlacklist.Contains(processName.ToLowerInvariant()))
+        return IsProcesInList(processName, ProcessBlacklist, WildcardProcessBlacklist);
+    }
+
+    private bool IsProcesInList(string processName, IReadOnlySet<string> fullProcessList, IReadOnlySet<string> wildcardProcessList)
+    {
+        if (fullProcessList.Contains(processName.ToLowerInvariant()))
         {
             return true;
         }
 
-        if (WildcardProcessBlacklist.Any(wildcardExpression => FileSystemName.MatchesSimpleExpression(wildcardExpression, processName, true)))
+        if (wildcardProcessList.Any(wildcardExpression => FileSystemName.MatchesSimpleExpression(wildcardExpression, processName, true)))
         {
             return true;
         }

--- a/src/EnergyStarX/Strings/af-ZA/Resources.resw
+++ b/src/EnergyStarX/Strings/af-ZA/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/ar-SA/Resources.resw
+++ b/src/EnergyStarX/Strings/ar-SA/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/ca-ES/Resources.resw
+++ b/src/EnergyStarX/Strings/ca-ES/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/cs-CZ/Resources.resw
+++ b/src/EnergyStarX/Strings/cs-CZ/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/da-DK/Resources.resw
+++ b/src/EnergyStarX/Strings/da-DK/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/de-DE/Resources.resw
+++ b/src/EnergyStarX/Strings/de-DE/Resources.resw
@@ -240,6 +240,7 @@ Siehe [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// Ein Prozessname pro Zeile
 // Doppelter Schrägstrich und Inhalt danach in jeder Zeile werden ignoriert
+// Supports "?" and "*" wildcards
     
 // Nicht uns
 EnergyStar.exe
@@ -366,6 +367,7 @@ Klicke erneut auf die Pause-Taste, um fortzufahren.</value>
     <value>// Prozessname pro Zeile
 // Zeile hinter einem doppelten Schrägstrich wird ignoriert
 // Sie müssen in der gleichen Windows-Sitzung sein wie der Prozess, den Sie drosseln möchten, und Sie müssen dieselben oder höhere Privilegien haben
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/el-GR/Resources.resw
+++ b/src/EnergyStarX/Strings/el-GR/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/en-us/Resources.resw
+++ b/src/EnergyStarX/Strings/en-us/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -365,6 +366,7 @@ Click the pause button again to resume.</value>
   <data name="DefaultProcessBlacklist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
 </value>
   </data>

--- a/src/EnergyStarX/Strings/es-ES/Resources.resw
+++ b/src/EnergyStarX/Strings/es-ES/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/fi-FI/Resources.resw
+++ b/src/EnergyStarX/Strings/fi-FI/Resources.resw
@@ -240,6 +240,7 @@ Tehtäväpalkissa pitäisi näkyä vihreä lehti.
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// Yksi prosessin nimi riviä kohden
 // Kaksoiskauttaviivarivit jätetään huomiotta
+// Supports "?" and "*" wildcards
 
 // Ei me
 EnergyStar.exe
@@ -366,6 +367,7 @@ Jatka painamalla taukonappulaa.</value>
     <value>// Yksi prosessi riviä kohden
 // Kaksoiskauttaviivarivit jätetään huomiotta
 // Sinun tulee olla samassa istunnossa kuin ohjelmassa, jota haluat tehostaa ja sinulla tulee olla väh. samat oikeudet
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/fr-FR/Resources.resw
+++ b/src/EnergyStarX/Strings/fr-FR/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/he-IL/Resources.resw
+++ b/src/EnergyStarX/Strings/he-IL/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/hu-HU/Resources.resw
+++ b/src/EnergyStarX/Strings/hu-HU/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/it-IT/Resources.resw
+++ b/src/EnergyStarX/Strings/it-IT/Resources.resw
@@ -235,6 +235,7 @@ Leggete [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develo
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// Un nome di processo per riga
 // Doppio slash e contenuto dopo di esso in ogni riga verranno ignorati
+// Supports "?" and "*" wildcards
     
 // Non noi stessi
 EnergyStar.exe
@@ -361,6 +362,7 @@ Fare nuovamente clic sul pulsante di pausa per ripristinare.</value>
     <value>// Un nome di processo per riga
 // Doppio slash e contenuto dopo di esso in ogni riga verranno ignorati
 // Devi essere nella stessa sessione di Windows come il processo che vuoi limitare, e hanno lo stesso privilegio o superiore
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/ja-JP/Resources.resw
+++ b/src/EnergyStarX/Strings/ja-JP/Resources.resw
@@ -240,6 +240,7 @@ Energy Star X は、Windows 11 の [EcoQoS API](https://devblogs.microsoft.com/p
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// プロセス名は1行に1つ
 // 各行のダブルスラッシュとそれ以降の内容は無視されます。
+// Supports "?" and "*" wildcards
 
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ firefox.exe</value>
     <value>// プロセス名は1行に1つ
 // 各行のダブルスラッシュとそれ以降の内容は無視されます。
 // 制限したいプロセスと同じ Windows セッションにおり、かつ同じかそれ以上の権限を持っている必要があります。
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/ko-KR/Resources.resw
+++ b/src/EnergyStarX/Strings/ko-KR/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/nl-NL/Resources.resw
+++ b/src/EnergyStarX/Strings/nl-NL/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/no-NO/Resources.resw
+++ b/src/EnergyStarX/Strings/no-NO/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/pl-PL/Resources.resw
+++ b/src/EnergyStarX/Strings/pl-PL/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/pt-BR/Resources.resw
+++ b/src/EnergyStarX/Strings/pt-BR/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/pt-PT/Resources.resw
+++ b/src/EnergyStarX/Strings/pt-PT/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/ro-RO/Resources.resw
+++ b/src/EnergyStarX/Strings/ro-RO/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/ru-RU/Resources.resw
+++ b/src/EnergyStarX/Strings/ru-RU/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/sr-SP/Resources.resw
+++ b/src/EnergyStarX/Strings/sr-SP/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/sv-SE/Resources.resw
+++ b/src/EnergyStarX/Strings/sv-SE/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/tr-TR/Resources.resw
+++ b/src/EnergyStarX/Strings/tr-TR/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/uk-UA/Resources.resw
+++ b/src/EnergyStarX/Strings/uk-UA/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/vi-VN/Resources.resw
+++ b/src/EnergyStarX/Strings/vi-VN/Resources.resw
@@ -240,6 +240,7 @@ See [Contributing.md](https://github.com/JasonWei512/EnergyStarX/blob/develop/do
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
+// Supports "?" and "*" wildcards
     
 // Not ourselves
 EnergyStar.exe
@@ -366,6 +367,7 @@ Click the pause button again to resume.</value>
     <value>// One process name per line
 // Double slash and content after it in each line will be ignored
 // You need to be in the same Windows Session as the process you want to throttle, and have the same or higher privilege
+// Supports "?" and "*" wildcards
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/zh-Hant/Resources.resw
+++ b/src/EnergyStarX/Strings/zh-Hant/Resources.resw
@@ -241,6 +241,7 @@ Energy Star X （能源之星 X）是開源的 EnergyStar 圖形化應用程式�
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// 每行一個進程名
 // 每行中雙斜槓以及之後的内容會被忽略
+// 支援「?」和「*」萬用字元
 
 // 排除我們自己
 EnergyStar.exe
@@ -367,6 +368,7 @@ firefox.exe</value>
     <value>// 每行一個進程名稱
 // 每行中雙斜槓以及之後的内容會被忽略
 // 您需要和您想要限制的進程在同一個 Windows 會話中，且擁有相同或更高的權限
+// 支援「?」和「*」萬用字元
 </value>
   </data>
   <data name="Settings_ProcessWhitelist.Description" xml:space="preserve">

--- a/src/EnergyStarX/Strings/zh-hans/Resources.resw
+++ b/src/EnergyStarX/Strings/zh-hans/Resources.resw
@@ -240,6 +240,7 @@
   <data name="DefaultProcessWhitelist" xml:space="preserve">
     <value>// 每行一个进程名
 // 每行中双斜杠以及之后的内容会被忽略
+// 支持 "?" 和 "*" 通配符
 
 // 排除我们自己
 EnergyStar.exe
@@ -365,6 +366,7 @@ firefox.exe</value>
   <data name="DefaultProcessBlacklist" xml:space="preserve">
     <value>// 每行一个进程名
 // 每行中双斜杠以及之后的内容会被忽略
+// 支持 "?" 和 "*" 通配符
 // 你需要和你想要限制的进程在同一个 Windows Session 中，且拥有相同或更高的权限
 </value>
   </data>


### PR DESCRIPTION
Solve https://github.com/JasonWei512/EnergyStarX/issues/61.

For example, `adobe*.exe` will match all processes whose name start with "adobe".