### PR TITLE
Fix: Wrong title in process black/white list editor dialog

### DIFF
--- a/src/EnergyStarX/ViewModels/SettingsViewModel.cs
+++ b/src/EnergyStarX/ViewModels/SettingsViewModel.cs
@@ -133,6 +133,9 @@ public partial class SettingsViewModel : ObservableRecipient
     private void ShowProcessWhitelistEditorDialog()
     {
         ProcessWhitelistString = settingsService.ProcessWhitelistString;
+        OnPropertyChanged(nameof(ProcessWhitelistModified));
+        OnPropertyChanged(nameof(ProcessWhitelistEditorDialogTitle));
+
         ProcessWhitelistEditorDialogShowRequested?.Invoke(this, EventArgs.Empty);
     }
 
@@ -155,6 +158,9 @@ public partial class SettingsViewModel : ObservableRecipient
     private void ShowProcessBlacklistEditorDialog()
     {
         ProcessBlacklistString = settingsService.ProcessBlacklistString;
+        OnPropertyChanged(nameof(ProcessBlacklistModified));
+        OnPropertyChanged(nameof(ProcessBlacklistEditorDialogTitle));
+
         ProcessBlacklistEditorDialogShowRequested?.Invoke(this, EventArgs.Empty);
     }
 


### PR DESCRIPTION
If you modify the process blacklist/whitelist and save, next time you open the process list editor dialog, you will still see "Modified" in the dialog's title.

This PR fixes this bug.