### PR TITLE
Fix: System tray icon does not show tooltip when hovered over

### DIFF
--- a/src/EnergyStarX/EnergyStarX.csproj
+++ b/src/EnergyStarX/EnergyStarX.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
     <PackageReference Include="CommunityToolkit.WinUI" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
-    <PackageReference Include="H.NotifyIcon" Version="2.0.108" />
+    <PackageReference Include="H.NotifyIcon" Version="2.0.116" />
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.2" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />

--- a/src/EnergyStarX/Services/SystemTrayIconService.cs
+++ b/src/EnergyStarX/Services/SystemTrayIconService.cs
@@ -38,8 +38,13 @@ public class SystemTrayIconService : ISystemTrayIconService
         {
             Items =
             {
-                new PopupMenuItem("Open".ToLocalized(), async (s, e) => await dispatcherQueue.EnqueueAsync(() => windowService.ShowAppWindow())),
-                new PopupMenuItem("Exit".ToLocalized(), async (s, e) => await dispatcherQueue.EnqueueAsync(() => windowService.ExitApp()))
+                new PopupMenuItem(
+                    "Open".ToLocalized(),
+                    async (s, e) => await dispatcherQueue.EnqueueAsync(() => windowService.ShowAppWindow())),
+
+                new PopupMenuItem(
+                    "Exit".ToLocalized(),
+                    async (s, e) => await dispatcherQueue.EnqueueAsync(() => windowService.ExitApp()))
             }
         };
 


### PR DESCRIPTION
`H.NotifyIcon` version `2.0.113` has fixed the bug that system tray icon does not show tooltip when hovered over on Windows 11.