### PR TITLE
Whitelist: Add LockApp & Tabtip

### DIFF
--- a/src/EnergyStarX/Strings/af-ZA/Resources.resw
+++ b/src/EnergyStarX/Strings/af-ZA/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/ar-SA/Resources.resw
+++ b/src/EnergyStarX/Strings/ar-SA/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/ca-ES/Resources.resw
+++ b/src/EnergyStarX/Strings/ca-ES/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/cs-CZ/Resources.resw
+++ b/src/EnergyStarX/Strings/cs-CZ/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/da-DK/Resources.resw
+++ b/src/EnergyStarX/Strings/da-DK/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/de-DE/Resources.resw
+++ b/src/EnergyStarX/Strings/de-DE/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/el-GR/Resources.resw
+++ b/src/EnergyStarX/Strings/el-GR/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/en-us/Resources.resw
+++ b/src/EnergyStarX/Strings/en-us/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/es-ES/Resources.resw
+++ b/src/EnergyStarX/Strings/es-ES/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/fi-FI/Resources.resw
+++ b/src/EnergyStarX/Strings/fi-FI/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/fr-FR/Resources.resw
+++ b/src/EnergyStarX/Strings/fr-FR/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/he-IL/Resources.resw
+++ b/src/EnergyStarX/Strings/he-IL/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/hu-HU/Resources.resw
+++ b/src/EnergyStarX/Strings/hu-HU/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/it-IT/Resources.resw
+++ b/src/EnergyStarX/Strings/it-IT/Resources.resw
@@ -260,6 +260,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/ja-JP/Resources.resw
+++ b/src/EnergyStarX/Strings/ja-JP/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/ko-KR/Resources.resw
+++ b/src/EnergyStarX/Strings/ko-KR/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/nl-NL/Resources.resw
+++ b/src/EnergyStarX/Strings/nl-NL/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/no-NO/Resources.resw
+++ b/src/EnergyStarX/Strings/no-NO/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/pl-PL/Resources.resw
+++ b/src/EnergyStarX/Strings/pl-PL/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/pt-BR/Resources.resw
+++ b/src/EnergyStarX/Strings/pt-BR/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/pt-PT/Resources.resw
+++ b/src/EnergyStarX/Strings/pt-PT/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/ro-RO/Resources.resw
+++ b/src/EnergyStarX/Strings/ro-RO/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/ru-RU/Resources.resw
+++ b/src/EnergyStarX/Strings/ru-RU/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/sr-SP/Resources.resw
+++ b/src/EnergyStarX/Strings/sr-SP/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/sv-SE/Resources.resw
+++ b/src/EnergyStarX/Strings/sv-SE/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/tr-TR/Resources.resw
+++ b/src/EnergyStarX/Strings/tr-TR/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/uk-UA/Resources.resw
+++ b/src/EnergyStarX/Strings/uk-UA/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/vi-VN/Resources.resw
+++ b/src/EnergyStarX/Strings/vi-VN/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // IME
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/zh-Hant/Resources.resw
+++ b/src/EnergyStarX/Strings/zh-Hant/Resources.resw
@@ -266,6 +266,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // 輸入法
 ChsIME.exe
 ctfmon.exe

--- a/src/EnergyStarX/Strings/zh-hans/Resources.resw
+++ b/src/EnergyStarX/Strings/zh-hans/Resources.resw
@@ -265,6 +265,8 @@ StartMenuExperienceHost.exe
 SearchHost.exe
 sihost.exe
 fontdrvhost.exe
+LockApp.exe
+TabTip.exe
 // 输入法
 ChsIME.exe
 ctfmon.exe


### PR DESCRIPTION
LockApp is the lock screen, and TabTip is the touch keyboard. 

They can be very, very unresponsive then throttled.